### PR TITLE
Use GetMod to set mod directory

### DIFF
--- a/Concepts/Constants.cs
+++ b/Concepts/Constants.cs
@@ -35,14 +35,7 @@ namespace QudUX.Concepts
             {
                 if (string.IsNullOrEmpty(_modDirectory))
                 {
-                    ModManager.ForEachMod(delegate (ModInfo mod)
-                    {
-                        if (mod?.manifest?.id == "QudUX" || mod?.workshopInfo?.Title == "QudUX")
-                        {
-                            _modDirectory = mod.Path;
-                            return;
-                        }
-                    });
+                    _modDirectory = ModManager.GetMod("QudUX")?.Path;
                 }
                 return _modDirectory;
             }


### PR DESCRIPTION
Just a small change for 201.89 with the mod compilation update, several of the referenced fields changed capitalisation.

Would like to provision ModInfo and Harmony instances directly after compilation for manual patching without attributes, eventually :tongue: 