### PR TITLE
(probably) Botched fix for 2.0.204.68

### DIFF
--- a/Screen Extenders/CreateCharacterExtender.cs
+++ b/Screen Extenders/CreateCharacterExtender.cs
@@ -64,11 +64,12 @@ namespace QudUX.ScreenExtenders
         public static void ApplyTileToEffects(GameObject target, string newTile)
         {
             //Sets the new tile to several effects that would otherwise override it.
-            if (target.HasPart(typeof(HologramMaterial)))
+            // HologramMaterial does not contain .Tile
+            /*if (target.HasPart(typeof(HologramMaterial)))
             {
                 HologramMaterial part = target.GetPart<HologramMaterial>();
                 part.Tile = newTile;
-            }
+            }*/
             if (target.HasPart(typeof(HologramMaterialPrimary)))
             {
                 HologramMaterialPrimary part = target.GetPart<HologramMaterialPrimary>();

--- a/Screen Extenders/EnhancedScoreBoard.cs
+++ b/Screen Extenders/EnhancedScoreBoard.cs
@@ -48,7 +48,7 @@ namespace QudUX.ScreenExtenders
 
     public class EnhancedScoreEntry : ScoreEntry2
     {
-        public EnhancedScoreEntry(ScoreEntry2 scoreEntry) : base(scoreEntry.Score, scoreEntry.Description, scoreEntry.Details, scoreEntry.Turns, scoreEntry.GameId, scoreEntry.GameMode)
+        public EnhancedScoreEntry(ScoreEntry2 scoreEntry) : base(scoreEntry.Score, scoreEntry.Details, scoreEntry.Turns, scoreEntry.GameId, scoreEntry.GameMode, scoreEntry.Level, scoreEntry.Name)
         {
 
             if ((scoreEntry == null) || (string.IsNullOrEmpty(scoreEntry.Details)))

--- a/Screens/QudUX_InventoryScreen.cs
+++ b/Screens/QudUX_InventoryScreen.cs
@@ -571,7 +571,7 @@ namespace XRL.UI
                 Buffer.Goto(34, 24);
                 Buffer.Write("{{y|[{{W|?}} view keys]}}");
 
-                TextConsole.DrawBuffer(Buffer, ImposterManager.getImposterUpdateFrame()); //need to update imposters because we've toggled their visibility
+                TextConsole.DrawBuffer(Buffer, ImposterManager.getImposterUpdateFrame(Buffer)); //need to update imposters because we've toggled their visibility
                 if (!XRL.Core.XRLCore.Core.Game.Running)
                 {
                     if (bShowInventoryTiles)

--- a/Utilities/JournalUtilities.cs
+++ b/Utilities/JournalUtilities.cs
@@ -34,8 +34,7 @@ namespace QudUX.Utilities
         public static string GenerateName()
         {
             string text;
-            text = NameMaker.MakeName(null, null, null, null, "Qudish", null, null, null, "Site");
-
+            text = NameMaker.MakeName(null, null, null, null, "Qudish", null, null, null, null, "Site");
             int chance = 50;
             if (chance.in100())
             {

--- a/Utilities/TileMaker.cs
+++ b/Utilities/TileMaker.cs
@@ -133,15 +133,9 @@ namespace QudUX.Utilities
                 return;
             }
             RenderEvent renderData = new RenderEvent();
-            Examiner examinerPart = go.GetPart<Examiner>();
-            if (examinerPart != null && !string.IsNullOrEmpty(examinerPart.UnknownTile) && !go.Understood())
-            {
-                renderData.Tile = examinerPart.UnknownTile;
-            }
-            else
-            {
-                renderData.Tile = go.pRender.Tile;
-            }
+
+            renderData.Tile = go.pRender.Tile;
+
             if (!string.IsNullOrEmpty(pRender.TileColor))
             {
                 renderData.ColorString = pRender.TileColor;


### PR DESCRIPTION
- CreateCharacterExtender HologramMaterial does not contain .Tile, removed if statement requiring it
- enhanced scoreboard had too many arguments
- inventory screen required Buffer reference
- journal utilites MakeName required more arguments